### PR TITLE
ci: install source check tooling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install source-check tooling
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/distribution-release.yml
+++ b/.github/workflows/distribution-release.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with: { bun-version: 1.3.14 }
+      - name: Install source-check tooling
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
       - run: bun install --frozen-lockfile
       - run: bun install --frozen-lockfile
         working-directory: frontend


### PR DESCRIPTION
Fixes the release and Runtime Checks runners by installing ripgrep before source checks. The v0.1.17 release gate previously failed only because rg was absent from the GitHub Ubuntu image. Full local bun run check remains green.