### PR TITLE
fix: remove stale audit context test path

### DIFF
--- a/scripts/debug/gpt.cjs
+++ b/scripts/debug/gpt.cjs
@@ -355,7 +355,6 @@ const CROSS_FILES = {
     'runtime/__tests__/helpers/cross-j.ts',
     'runtime/__tests__/cross-jurisdiction-swap.test.ts',
     'runtime/__tests__/cross-jurisdiction-security.test.ts',
-    'runtime/__tests__/cross-jurisdiction-reorder.test.ts',
     'runtime/__tests__/multi-jurisdiction-entity.test.ts',
     'runtime/__tests__/orderbook-lifecycle.test.ts',
     'runtime/__tests__/orderbook-matching-fallback.test.ts',


### PR DESCRIPTION
Clean CI regeneration of llms context failed because the audit profile still referenced cross-jurisdiction-reorder.test.ts, deleted in commit 35e5c9719. Removes that stale path. Verified with XLN_REBUILD_LLMS=1 bun copy-static-files.js and a full bun run check.