### PR TITLE
build: trust Electron distribution install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "electron",
+  ],
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -243,5 +243,8 @@
     "tevm": "^1.0.0-next.149",
     "ws": "^8.21.1"
   },
+  "trustedDependencies": [
+    "electron"
+  ],
   "type": "module"
 }


### PR DESCRIPTION
Bun blocks dependency lifecycle scripts by default. Explicitly trusts Electron so clean macOS release runners download Electron.app before the mandatory desktop smoke/package step. Full bun run check is green and local Electron is v42.7.0.