### PR TITLE
fix: bootstrap Electron binary for packaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,9 +59,6 @@
       },
     },
   },
-  "trustedDependencies": [
-    "electron",
-  ],
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -243,8 +243,5 @@
     "tevm": "^1.0.0-next.149",
     "ws": "^8.21.1"
   },
-  "trustedDependencies": [
-    "electron"
-  ],
   "type": "module"
 }

--- a/scripts/native/build-platforms.ts
+++ b/scripts/native/build-platforms.ts
@@ -436,7 +436,10 @@ function packageDesktopApp(): NativeArtifact[] {
 
 	const electronApp = path.join(ROOT, 'node_modules/electron/dist/Electron.app');
 	if (!existsSync(electronApp)) {
-		throw new Error(`Missing Electron.app at ${electronApp}. Run bun install or bunx electron --version first.`);
+		run('bunx', ['electron', '--version'], ROOT);
+	}
+	if (!existsSync(electronApp)) {
+		throw new Error(`Electron bootstrap completed without creating ${electronApp}`);
 	}
 	if (!existsSync(path.join(BUILD_DIR, 'index.html'))) {
 		throw new Error(`Missing ${path.join(BUILD_DIR, 'index.html')}. Build frontend before packaging desktop.`);


### PR DESCRIPTION
Electron 42 downloads its platform bundle lazily rather than through postinstall. The desktop packager now runs the official Electron CLI bootstrap when Electron.app is absent, then fails if the bundle still does not exist. Mandatory desktop smoke remains enabled. Verified by native tests, desktop package smoke, and full bun run check.